### PR TITLE
Handle query parameters of type array and encoded as comma separated values 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var Package = require('../package.json'),
     Thing = require('core-util-is'),
     Builder = require('swaggerize-builder'),
     Utils = require('swaggerize-builder/lib/utils'),
+    Joi = require('joi'),
     Path = require('path');
 
 module.exports = {
@@ -79,16 +80,50 @@ module.exports = {
                             config.validate.params = config.validate.params || {};
                             config.validate.params[validator.parameter.name] = validator.schema;
                             break;
-                        case 'query':
-                            config.validate.query = config.validate.query || {};
-                            config.validate.query[validator.parameter.name] = validator.schema;
-                            break;
                         case 'body':
                         case 'form':
                             config.validate.payload = validator.schema;
                             break;
                     }
                 });
+
+                config.validate.query = function(value, options, callback) {
+                    var validationErrors = new Array();
+                    for( var i= 0, j=Object.keys(value).length; i<j; i++ ) {
+                        route.validators.forEach(function (validator) {
+                            if( validator.parameter.name === Object.keys(value)[i] ) {
+                                if( validator.parameter.type === 'array' ) {
+                                    validator.validate(value[validator.parameter.name], function(err, result) {
+                                        if( err ) {
+                                            validationErrors.push(err);
+                                        }
+                                        else {
+                                            value[validator.parameter.name] = result;
+                                        }
+                                    });
+                                }
+                                else {
+                                    Joi.validate(value[validator.parameter.name], validator.schema, options, function(err, result) {
+                                        if( err ) {
+                                            validationErrors.push(err);
+                                        }
+                                        else {
+                                            value[validator.parameter.name] = result;
+                                        }
+                                    });
+                                }
+                            }
+                        });
+                    }
+
+                    if( validationErrors.length>0 ) {
+                        callback(validationErrors[0]);
+                    }
+                    else {
+                        callback(null, value);
+                    }
+
+                };
             }
 
             //Define the route

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hapi": "^8.0.0",
     "hoek": "^2.6.0",
     "swaggerize-builder": "^2.0.0",
-    "core-util-is": "^1.0.1"
+    "core-util-is": "^1.0.1",
+    "joi": "^4.7.0"
   },
   "devDependencies": {
     "tape": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "hapi": "^8.0.0",
     "hoek": "^2.6.0",
-    "swaggerize-builder": "^2.0.0",
+    "swaggerize-builder": "git+https://github.com/guybedo/swaggerize-builder",
     "core-util-is": "^1.0.1",
     "joi": "^4.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "hapi": "^8.0.0",
     "hoek": "^2.6.0",
-    "swaggerize-builder": "git+https://github.com/guybedo/swaggerize-builder",
+    "swaggerize-builder": "^2.0.0",
     "core-util-is": "^1.0.1",
     "joi": "^4.7.0"
   },


### PR DESCRIPTION
Fix for the issue: https://github.com/krakenjs/swaggerize-hapi/issues/25

Swagger spec specifies that query parameters declared as arrays are encoded as a comma separated values string ( https://github.com/swagger-api/swagger-ui/issues/810 ).

This format was not handled correctly by swaggerize-hapi.