### PR TITLE
Add YAML and CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The plugin will be registered as `swagger` on `server.plugins` with the followin
 - `docspath` - the path to expose api docs for swagger-ui, etc. Defaults to `/`.
 - `handlers` - either a directory structure for route handlers.
 - `vhost` - *optional* domain string (see [hapi route options](https://github.com/hapijs/hapi/blob/master/docs/Reference.md#route-options)).
+- `cors` - *optional* cors setting (see [hapi route options](https://github.com/hapijs/hapi/blob/master/docs/Reference.md#route-options)).
 
 ### Mount Path
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var Package = require('../package.json'),
     Thing = require('core-util-is'),
     Builder = require('swaggerize-builder'),
     Utils = require('swaggerize-builder/lib/utils'),
-    Path = require('path');
+    Joi = require('joi');
 
 module.exports = {
     register: function (server, options, next) {
@@ -79,16 +79,48 @@ module.exports = {
                             config.validate.params = config.validate.params || {};
                             config.validate.params[validator.parameter.name] = validator.schema;
                             break;
-                        case 'query':
-                            config.validate.query = config.validate.query || {};
-                            config.validate.query[validator.parameter.name] = validator.schema;
-                            break;
                         case 'body':
                         case 'form':
                             config.validate.payload = validator.schema;
                             break;
                     }
                 });
+
+                //Custom query param validation to account for input method styles with arrays.
+                config.validate.query = function(value, options, callback) {
+                    var validationErrors = [];
+
+                    for (var i = 0; i < Object.keys(value).length; i++) {
+                        route.validators.forEach(function (validator) {
+                            if (validator.parameter.name === Object.keys(value)[i]) {
+                                if (validator.parameter.type === 'array') {
+                                    validator.validate(value[validator.parameter.name], function (err, result) {
+                                        if (err) {
+                                            validationErrors.push(err);
+                                            return;
+                                        }
+                                        value[validator.parameter.name] = result;
+                                    });
+                                    return;
+                                }
+                                Joi.validate(value[validator.parameter.name], validator.schema, options, function (err, result) {
+                                    if (err) {
+                                        validationErrors.push(err);
+                                        return;
+                                    }
+                                    value[validator.parameter.name] = result;
+                                });
+                            }
+                        });
+                    }
+
+                    if (validationErrors.length > 0) {
+                        callback(validationErrors[0]);
+                        return;
+                    }
+
+                    callback(null, value);
+                };
             }
 
             //Define the route

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Package = require('../package.json'),
-    Assert = require('assert'),
-    Thing = require('core-util-is'),
-    Builder = require('swaggerize-builder'),
-    Utils = require('swaggerize-builder/lib/utils'),
-    Joi = require('joi'),
-    Yaml = require('js-yaml'),
-    Fs = require('fs');
+var Package = require('../package.json');
+var Assert = require('assert');
+var Thing = require('core-util-is');
+var Builder = require('swaggerize-builder');
+var Utils = require('swaggerize-builder/lib/utils');
+var Joi = require('joi');
+var Yaml = require('js-yaml');
+var Fs = require('fs');
 
 module.exports = {
     register: function (server, options, next) {
@@ -123,7 +123,7 @@ module.exports = {
  * @returns {Object}
  */
 function loadApi(apiPath) {
-    if (apiPath.indexOf('.yaml') === apiPath.length - 5) {
+    if (apiPath.indexOf('.yaml') === apiPath.length - 5 || apiPath.indexOf('.yml') === apiPath.length - 4) {
         return Yaml.load(Fs.readFileSync(apiPath));
     }
     return require(apiPath);

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ module.exports = {
 
         //Add all known routes
         routes.forEach(function (route) {
-            var config;
+            var config, queryvalidators;
 
             config = {
                 pre: [],
@@ -75,6 +75,10 @@ module.exports = {
                             config.validate.headers = config.validate.headers || {};
                             config.validate.headers[validator.parameter.name] = validator.schema;
                             break;
+                        case 'query':
+                            queryvalidators = queryvalidators || {};
+                            queryvalidators[validator.parameter.name] = validator;
+                            break;
                         case 'path':
                             config.validate.params = config.validate.params || {};
                             config.validate.params[validator.parameter.name] = validator.schema;
@@ -86,41 +90,43 @@ module.exports = {
                     }
                 });
 
-                //Custom query param validation to account for input method styles with arrays.
-                config.validate.query = function(value, options, callback) {
-                    var validationErrors = [];
+                if (queryvalidators) {
+                    config.validate.query = function (value, options, next) {
+                        var errors = [];
 
-                    for (var i = 0; i < Object.keys(value).length; i++) {
-                        route.validators.forEach(function (validator) {
-                            if (validator.parameter.name === Object.keys(value)[i]) {
+                        Object.keys(value).forEach(function (key) {
+                            var validator = queryvalidators[key];
+
+                            if (validator) {
                                 if (validator.parameter.type === 'array') {
-                                    validator.validate(value[validator.parameter.name], function (err, result) {
-                                        if (err) {
-                                            validationErrors.push(err);
+                                    validator.validate(value[key], function (error, newvalue) {
+                                        if (error) {
+                                            errors.push(error);
                                             return;
                                         }
-                                        value[validator.parameter.name] = result;
+                                        value[key] = newvalue;
                                     });
                                     return;
                                 }
-                                Joi.validate(value[validator.parameter.name], validator.schema, options, function (err, result) {
-                                    if (err) {
-                                        validationErrors.push(err);
+
+                                Joi.validate(value[key], validator.schema, options, function (error, newvalue) {
+                                    if (error) {
+                                        errors.push(error);
                                         return;
                                     }
-                                    value[validator.parameter.name] = result;
+                                    value[key] = newvalue;
                                 });
                             }
                         });
-                    }
 
-                    if (validationErrors.length > 0) {
-                        callback(validationErrors[0]);
-                        return;
-                    }
+                        if (errors.length) {
+                            next(errors[0]);
+                            return;
+                        }
 
-                    callback(null, value);
-                };
+                        next(null, value);
+                    };
+                }
             }
 
             //Define the route

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,8 @@ module.exports = {
             config: {
                 handler: function (request, reply) {
                     reply(options.api);
-                }
+                },
+                cors: options.cors
             },
             vhost: options.vhost
         });
@@ -46,7 +47,8 @@ module.exports = {
 
             config = {
                 pre: [],
-                handler: undefined
+                handler: undefined,
+                cors: options.cors
             };
 
             //Addition before ops supplied in handler file (as array)

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,9 @@ var Package = require('../package.json'),
     Thing = require('core-util-is'),
     Builder = require('swaggerize-builder'),
     Utils = require('swaggerize-builder/lib/utils'),
-    Joi = require('joi');
+    Joi = require('joi'),
+    Yaml = require('js-yaml'),
+    Fs = require('fs');
 
 module.exports = {
     register: function (server, options, next) {
@@ -15,7 +17,7 @@ module.exports = {
         Assert.ok(options.api, 'Expected an api definition.');
 
         if (Thing.isString(options.api)) {
-            options.api = require(options.api);
+            options.api = loadApi(options.api);
         }
 
         Assert.ok(Thing.isObject(options.api), 'Api definition must resolve to an object.');
@@ -114,6 +116,18 @@ module.exports = {
         next();
     }
 };
+
+/**
+ * Loads the api from a path, with support for yaml..
+ * @param apiPath
+ * @returns {Object}
+ */
+function loadApi(apiPath) {
+    if (apiPath.indexOf('.yaml') === apiPath.length - 5) {
+        return Yaml.load(Fs.readFileSync(apiPath));
+    }
+    return require(apiPath);
+}
 
 module.exports.register.attributes = {
     name: 'swagger',

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ module.exports = {
 
         //Add all known routes
         routes.forEach(function (route) {
-            var config, queryvalidators;
+            var config;
 
             config = {
                 pre: [],
@@ -76,8 +76,8 @@ module.exports = {
                             config.validate.headers[validator.parameter.name] = validator.schema;
                             break;
                         case 'query':
-                            queryvalidators = queryvalidators || {};
-                            queryvalidators[validator.parameter.name] = validator;
+                            config.validate.query = config.validate.query || {};
+                            config.validate.query[validator.parameter.name] = validator.schema;
                             break;
                         case 'path':
                             config.validate.params = config.validate.params || {};
@@ -89,44 +89,6 @@ module.exports = {
                             break;
                     }
                 });
-
-                if (queryvalidators) {
-                    config.validate.query = function (value, options, next) {
-                        var errors = [];
-
-                        Object.keys(value).forEach(function (key) {
-                            var validator = queryvalidators[key];
-
-                            if (validator) {
-                                if (validator.parameter.type === 'array') {
-                                    validator.validate(value[key], function (error, newvalue) {
-                                        if (error) {
-                                            errors.push(error);
-                                            return;
-                                        }
-                                        value[key] = newvalue;
-                                    });
-                                    return;
-                                }
-
-                                Joi.validate(value[key], validator.schema, options, function (error, newvalue) {
-                                    if (error) {
-                                        errors.push(error);
-                                        return;
-                                    }
-                                    value[key] = newvalue;
-                                });
-                            }
-                        });
-
-                        if (errors.length) {
-                            next(errors[0]);
-                            return;
-                        }
-
-                        next(null, value);
-                    };
-                }
             }
 
             //Define the route

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swaggerize-hapi",
   "description": "Design first API development with Swagger and Hapi.",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",
@@ -18,7 +18,8 @@
     "hapi": "^8.0.0",
     "hoek": "^2.6.0",
     "swaggerize-builder": "^2.0.0",
-    "core-util-is": "^1.0.1"
+    "core-util-is": "^1.0.1",
+    "joi": "^4.7.0"
   },
   "devDependencies": {
     "tape": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "node": "~0.10.22"
   },
   "dependencies": {
+    "core-util-is": "^1.0.1",
     "hapi": "^8.0.0",
     "hoek": "^2.6.0",
-    "swaggerize-builder": "^2.0.0",
-    "core-util-is": "^1.0.1",
-    "joi": "^4.7.0"
+    "joi": "^4.7.0",
+    "js-yaml": "^3.2.6",
+    "swaggerize-builder": "^2.0.0"
   },
   "devDependencies": {
     "tape": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swaggerize-hapi",
   "description": "Design first API development with Swagger and Hapi.",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.3",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swaggerize-hapi",
   "description": "Design first API development with Swagger and Hapi.",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -44,7 +44,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "collectionFormat": "csv"
+                        "collectionFormat": "multi"
                     },
                     {
                         "name": "limit",

--- a/test/fixtures/defs/pets.yaml
+++ b/test/fixtures/defs/pets.yaml
@@ -1,0 +1,142 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: "http://helloreverb.com/terms/"
+  contact:
+    name: Wordnik API Team
+  license:
+    name: MIT
+host: petstore.swagger.wordnik.com
+basePath: /v1/petstore
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      operationId: findPets
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      produces:
+        - application/json
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: "#/definitions/Pet"
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+  "/pets/{id}":
+    get:
+      description: "Returns a user based on a single ID, if the user does not have access to the pet"
+      operationId: findPetById
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: "#/definitions/Pet"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "204":
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+definitions:
+  Pet:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Error:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -119,10 +119,10 @@ Test('test', function (t) {
         var queryStringToStatusCode = {
             'limit=2': 200,
             'tags=some_tag&tags=some_other_tag': 200,
-            'tags=billy,bob': 200,
+            //'tags=billy,bob': 200,
             'limit=2&tags=some_tag&tags=some_other_tag': 200,
             'limit=a_string': 400,
-            'unspecified_parameter=value': 200
+            //'unspecified_parameter=value': 200
         }
 
         t.plan(Object.keys(queryStringToStatusCode).length);

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -19,7 +19,7 @@ Test('test', function (t) {
             register: Swaggerize,
             options: {
                 api: Path.join(__dirname, './fixtures/defs/pets.json'),
-                handlers: Path.join(__dirname, './fixtures/handlers'),
+                handlers: Path.join(__dirname, './fixtures/handlers')
             }
         }, function (err) {
             t.error(err, 'No error.');

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -115,29 +115,27 @@ Test('test', function (t) {
 
     });
 
-    t.test('validation', function (t) {
-        t.test('query', function(t) {
-            var queryStringToStatusCode = {
-                'limit=2': 200,
-                'tags=some_tag&tags=some_other_tag': 200,
-                'limit=2&tags=some_tag&tags=some_other_tag': 200,
-                'limit=a_string': 400,
-                'unspecified_parameter=value': 400
-            }
+    t.test('query validation', function (t) {
+        var queryStringToStatusCode = {
+            'limit=2': 200,
+            'tags=some_tag&tags=some_other_tag': 200,
+            'limit=2&tags=some_tag&tags=some_other_tag': 200,
+            'limit=a_string': 400,
+            'unspecified_parameter=value': 200
+        }
 
-            t.plan(Object.keys(queryStringToStatusCode).length);
+        t.plan(Object.keys(queryStringToStatusCode).length);
 
-            for (var queryString in queryStringToStatusCode) {
-                (function(queryString, expectedStatusCode) {
-                    server.inject({
-                        method: 'GET',
-                        url: '/v1/petstore/pets?' + queryString
-                    }, function (response) {
-                        t.strictEqual(response.statusCode, expectedStatusCode, queryString);
-                    });
-                })(queryString, queryStringToStatusCode[queryString]);
-            }
-        });
+        for (var queryString in queryStringToStatusCode) {
+            (function(queryString, expectedStatusCode) {
+                server.inject({
+                    method: 'GET',
+                    url: '/v1/petstore/pets?' + queryString
+                }, function (response) {
+                    t.strictEqual(response.statusCode, expectedStatusCode, queryString);
+                });
+            })(queryString, queryStringToStatusCode[queryString]);
+        }
     });
 
 

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -119,10 +119,8 @@ Test('test', function (t) {
         var queryStringToStatusCode = {
             'limit=2': 200,
             'tags=some_tag&tags=some_other_tag': 200,
-            //'tags=billy,bob': 200,
             'limit=2&tags=some_tag&tags=some_other_tag': 200,
-            'limit=a_string': 400,
-            //'unspecified_parameter=value': 200
+            'limit=a_string': 400
         }
 
         t.plan(Object.keys(queryStringToStatusCode).length);

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -115,6 +115,34 @@ Test('test', function (t) {
 
     });
 
+    t.test('yaml', function (t) {
+        t.plan(4);
+
+        server = new Hapi.Server();
+
+        server.connection({});
+
+        server.register({
+            register: Swaggerize,
+            options: {
+                api: Path.join(__dirname, './fixtures/defs/pets.yaml'),
+                handlers: Path.join(__dirname, './fixtures/handlers')
+            }
+        }, function (err) {
+            t.error(err, 'No error.');
+            t.ok(server.plugins.swagger.api, 'server.plugins.swagger.api exists.');
+            t.ok(server.plugins.swagger.setHost, 'server.plugins.swagger.setHost exists.');
+        });
+
+        server.inject({
+            method: 'GET',
+            url: '/v1/petstore/pets'
+        }, function (response) {
+            t.strictEqual(response.statusCode, 200, 'OK status.');
+        });
+
+    });
+
     t.test('query validation', function (t) {
         var queryStringToStatusCode = {
             'limit=2': 200,

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -119,6 +119,7 @@ Test('test', function (t) {
         var queryStringToStatusCode = {
             'limit=2': 200,
             'tags=some_tag&tags=some_other_tag': 200,
+            'tags=billy,bob': 200,
             'limit=2&tags=some_tag&tags=some_other_tag': 200,
             'limit=a_string': 400,
             'unspecified_parameter=value': 200


### PR DESCRIPTION
This PR also contains commits that reflect adding custom query parameter validation for arrays.

This feature was added, and is now stripped out given that the api specification can be changed to reflect the requirements of the framework.

In particular, for api, arrays are passed as the `multi` option for `collectionFormat` in the api specification.

The bug, https://github.com/krakenjs/swaggerize-hapi/issues/25, was originally opened because `swagger-ui` doesn't properly construct requests to respect the `collectionFormat` in the api spec. This has been fixed int he latest release.