### PR TITLE
Feature/token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,32 @@ Example:
 ```
 
 Handler keys in files do *not* have to be namespaced in this way.
+
+### Authentication
+
+Support for swagger `apiKey` [security schemes](http://swagger.io/specification/#securitySchemeObject) requires that relevant authentication scheme and strategy are registered before the swaggerize-hapi plugin. See the [hapi docs](http://hapijs.com/tutorials/auth) for information about authentication schemes and strategies.
+
+The name of the hapi authentication strategy is expected to match the name field of the swagger [security requirement object](http://swagger.io/specification/#securityRequirementObject). 
+
+Example:
+
+```javascript
+server = new Hapi.Server();
+server.connection({});
+
+server.register({ register: AuthTokenScheme }, function (err) {
+    server.auth.strategy('api_key', 'auth-token-scheme', {
+        validateFunc: function (token, callback) {
+          // Implement validation here
+        }
+    });
+
+    server.register({
+        register: Swaggerize,
+        options: {
+            api: require('./config/pets.json'),
+            handlers: Path.join(__dirname, './handlers')
+        }
+    });
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,15 +100,18 @@ module.exports = {
             }
 
             if (route.security) {
-                var securityDefinitionName = Object.keys(route.security)[0];
-                Assert.ok(securityDefinitionName, 'Expected security scheme definition name.');
+                var securitySchemes = Object.keys(route.security);
+                Assert.ok(securitySchemes.length < 2, 'HAPI supports 1 authentication strategy per route.');
 
-                var securityDefinition = options.api.securityDefinitions[securityDefinitionName];
-                Assert.ok(securityDefinition, 'Expected security scheme to be defined.');
+                if (securitySchemes.length) {
+                    var securityDefinitionName = securitySchemes[0];
+                    var securityDefinition = options.api.securityDefinitions[securityDefinitionName];
 
-                Assert.ok(securityDefinition.type === 'apiKey', 'None api_key security schemes not supported.');
+                    Assert.ok(securityDefinition, 'Security scheme not defined.');
+                    Assert.ok(securityDefinition.type === 'apiKey', 'None api_key security schemes not supported.');
 
-                config.auth = securityDefinitionName;
+                    config.auth = securityDefinitionName;
+                }
             }
 
             //Define the route

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,18 @@ module.exports = {
                 });
             }
 
+            if (route.security) {
+                var securityDefinitionName = Object.keys(route.security)[0];
+                Assert.ok(securityDefinitionName, 'Expected security scheme definition name.');
+
+                var securityDefinition = options.api.securityDefinitions[securityDefinitionName];
+                Assert.ok(securityDefinition, 'Expected security scheme to be defined.');
+
+                Assert.ok(securityDefinition.type === 'apiKey', 'None api_key security schemes not supported.');
+
+                config.auth = securityDefinitionName;
+            }
+
             //Define the route
             server.route({
                 method: route.method,

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,17 +101,17 @@ module.exports = {
 
             if (route.security) {
                 var securitySchemes = Object.keys(route.security);
-                Assert.ok(securitySchemes.length < 2, 'HAPI supports 1 authentication strategy per route.');
 
-                if (securitySchemes.length) {
-                    var securityDefinitionName = securitySchemes[0];
+                securitySchemes.forEach(function (securityDefinitionName) {
                     var securityDefinition = options.api.securityDefinitions[securityDefinitionName];
 
                     Assert.ok(securityDefinition, 'Security scheme not defined.');
                     Assert.ok(securityDefinition.type === 'apiKey', 'None api_key security schemes not supported.');
 
-                    config.auth = securityDefinitionName;
-                }
+                    config.auth = config.auth || {};
+                    config.auth.strategies = config.auth.strategies || [];
+                    config.auth.strategies.push(securityDefinitionName);
+                });
             }
 
             //Define the route

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "devDependencies": {
     "tape": "^3.0.0",
     "jshint": "^2.4.1",
-    "istanbul": "~0.2.3"
+    "istanbul": "~0.2.3",
+    "boom": "~2.8.0"
   },
   "scripts": {
     "test": "tape test/*.js",

--- a/test/fixtures/defs/pets_authed.json
+++ b/test/fixtures/defs/pets_authed.json
@@ -31,6 +31,9 @@
                 "security": [
                   {
                     "api_key": []
+                  },
+                  {
+                    "api_key2": []
                   }
                 ],
                 "produces": [
@@ -83,7 +86,12 @@
     "securityDefinitions": {
         "api_key": {
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "authorization",
+            "in": "header"
+        },
+        "api_key2": {
+            "type": "apiKey",
+            "name": "authorization",
             "in": "header"
         }
     },

--- a/test/fixtures/defs/pets_authed.json
+++ b/test/fixtures/defs/pets_authed.json
@@ -1,0 +1,127 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "Wordnik API Team"
+        },
+        "license": {
+            "name": "MIT"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v1/petstore",
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Returns all pets from the system that the user has access to",
+                "operationId": "findPets",
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "api_key": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    },
+    "definitions": {
+        "Pet": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "Error": {
+            "type": "object",
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/test/fixtures/lib/stub-auth-token-scheme.js
+++ b/test/fixtures/lib/stub-auth-token-scheme.js
@@ -14,7 +14,7 @@ exports.register = function (server, options, next) {
 
                 options.validateFunc(token, function (err, isValid, credentials) {
                     if (err || !isValid) {
-                        return reply(Boom.unauthorized(), { credentials: credentials });
+                        return reply(Boom.unauthorized(null, 'stub-auth-token'), { credentials: credentials });
                     }
 
                     return reply.continue({ credentials: credentials });

--- a/test/fixtures/lib/stub-auth-token-scheme.js
+++ b/test/fixtures/lib/stub-auth-token-scheme.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Boom = require('boom');
+
+exports.register = function (server, options, next) {
+    server.auth.scheme('stub-auth-token', function (server, options) {
+        var scheme = {
+            authenticate: function (request, reply) {
+                var token = request.raw.req.headers.authorization;
+
+                if (!token) {
+                    return reply(Boom.unauthorized());
+                }
+
+                options.validateFunc(token, function (err, isValid, credentials) {
+                    if (err || !isValid) {
+                        return reply(Boom.unauthorized(), { credentials: credentials });
+                    }
+
+                    return reply.continue({ credentials: credentials });
+                });
+            }
+        };
+
+        return scheme;
+    });
+
+    next();
+};
+
+exports.register.attributes = {
+    name: 'stub-auth-token'
+};

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -140,10 +140,10 @@ Test('test', function (t) {
 
 });
 
-Test('token authentication', function (t) {
+Test('authentication', function (t) {
     var server;
 
-    t.test('server setup', function (t) {
+    t.test('token authentication', function (t) {
         t.plan(4);
 
         server = new Hapi.Server();
@@ -171,31 +171,23 @@ Test('token authentication', function (t) {
                 }
             }, function (err) {
                 t.error(err, 'No error.');
-                t.ok(server.plugins.swagger.api, 'server.plugins.swagger.api exists.');
-                t.ok(server.plugins.swagger.setHost, 'server.plugins.swagger.setHost exists.');
+
+                server.inject({
+                    method: 'GET',
+                    url: '/v1/petstore/pets'
+                }, function (response) {
+                    t.strictEqual(response.statusCode, 401, '401 status (unauthorized).');
+
+                    server.inject({
+                        method: 'GET',
+                        url: '/v1/petstore/pets',
+                        headers: { authorization: '12345' }
+                    }, function (response) {
+                        t.strictEqual(response.statusCode, 200, 'OK status.');
+                    });
+                });
             });
         });
-    });
-
-    t.test('token authentication', function (t) {
-        t.plan(2);
-
-        server.inject({
-            method: 'GET',
-            url: '/v1/petstore/pets'
-        }, function (response) {
-            t.strictEqual(response.statusCode, 401, '401 status (unauthorized).');
-
-            server.inject({
-                method: 'GET',
-                url: '/v1/petstore/pets',
-                headers: { authorization: '12345' }
-            }, function (response) {
-                t.strictEqual(response.statusCode, 200, 'OK status.');
-            });
-
-        });
-
     });
 });
 


### PR DESCRIPTION
Adds support for generation of hapi endpoint authentication for swagger `apiKey` security definitions. Relates to #31 but does not implement swagger's `basic` or `oauth2` security types definitions

Happy to  discuss any changes that might make this more likely to make it in :smile: 