### PR TITLE
fix payload check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,9 +91,8 @@ module.exports = {
                             config.validate.payload = validator.schema;
                             break;
                         case 'formData':
-                            config.validate.payload = function (value, options, next) {
-                                validator.validate(value, next);
-                            };
+                            config.validate.payload = config.validate.payload || {};
+                            config.validate.payload[validator.parameter.name] = validator.schema;
                             break;
                     }
                 });

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -33,7 +33,7 @@
                     {
                         "name": "upload",
                         "in": "formData",
-                        "type": "file",
+                        "type": "string",
                         "required": true
                     },
                     {

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -208,9 +208,10 @@ Test('authentication', function (t) {
 
 Test('form data', function (t) {
     var server;
+    var payload;
 
     t.test('success', function (t) {
-        t.plan(2);
+        t.plan(3);
 
         server = new Hapi.Server();
 
@@ -223,6 +224,7 @@ Test('form data', function (t) {
                 handlers: {
                     upload: {
                         $post: function (req, reply) {
+                            payload = req.payload;
                             reply();
                         }
                     }
@@ -241,6 +243,7 @@ Test('form data', function (t) {
             payload: 'name=thing&upload=asdf'
         }, function (response) {
             t.strictEqual(response.statusCode, 200, 'OK status.');
+            t.strictEqual(typeof payload, 'object');
         });
     });
 


### PR DESCRIPTION
According to http://hapijs.com/tutorials/validation#payload-parameters , payload should be handled like query parameters. The way it was done put the string '[object Object]' in request.payload. This pull request fix payload handling.
I fixed the tests : you can only upload files by submitting multipart/form-data. I suggest adding more tests to cover file uploads.