### PR TITLE
Hapi dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.10"
-  - "iojs"
-  - "iojs-v1.1.0"
+  - "stable"
+  - "4"
+  - "5"
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -17,17 +17,17 @@
   "dependencies": {
     "async": "^1.5.0",
     "core-util-is": "^1.0.1",
-    "hapi": "^13.0.0",
     "hoek": "^2.6.0",
     "joi": "^6.6.1",
     "js-yaml": "^3.2.6",
     "swaggerize-routes": "^1.0.3"
   },
   "devDependencies": {
-    "tape": "^3.0.0",
-    "jshint": "^2.4.1",
+    "boom": "~2.8.0",
+    "hapi": "^13.3.0",
     "istanbul": "~0.2.3",
-    "boom": "~2.8.0"
+    "jshint": "^2.4.1",
+    "tape": "^3.0.0"
   },
   "scripts": {
     "test": "tape test/*.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swaggerize-hapi",
   "description": "Design-driven apis with swagger 2.0 and hapi.",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "engines": {
-    "node": "~0.10.22"
+    "node": "4.x"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
- hapi is only needed for tests
- Upgrading a dependency without releasing a new version fucked me :)