### PR TITLE
#51 Remove trailing slash from docspath

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports = {
 
         options.basedir = options.basedir || process.cwd();
         options.docspath = Utils.prefix(options.docspath || '/api-docs', '/');
+        options.docspath = Utils.unsuffix(options.docspath, '/');
         options.api.basePath = Utils.prefix(options.api.basePath || '/', '/');
         basePath = Utils.unsuffix(options.api.basePath, '/');
 


### PR DESCRIPTION
Meaningless trailing slashes in URLs should be avoided. If someone wants to support URLs with trailing slashes, it can be easily achieved with following server extension:

```
server.ext('onRequest', function (request, reply) {
	request.path = request.path.replace(/\/$/, '');
	return reply.continue();
});
```