### PR TITLE
Adding a header parameter disallows other unspecified headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+#### Bug fixes
+
+- #50
 
 ### v2.0.0
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ module.exports = {
 
         //Add all known routes
         routes.forEach(function (route) {
-            var config, formValidators;
+            var config, formValidators, headers;
 
             config = {
                 pre: [],
@@ -77,8 +77,8 @@ module.exports = {
                 route.validators.forEach(function (validator) {
                     switch (validator.parameter.in) {
                         case 'header':
-                            config.validate.headers = config.validate.headers || {};
-                            config.validate.headers[validator.parameter.name] = validator.schema;
+                            headers = headers || {};
+                            headers[validator.parameter.name] = validator.schema;
                             break;
                         case 'query':
                             config.validate.query = config.validate.query || {};
@@ -99,6 +99,10 @@ module.exports = {
                             break;
                     }
                 });
+
+                if (headers && Object.keys(headers).length > 0) {
+                    config.validate.headers = Joi.object(headers).options({ allowUnknown: true });
+                }
 
                 if (!config.validate.payload && formValidators) {
                     config.validate.payload = function (value, options, next) {

--- a/test/fixtures/defs/pets_authed.json
+++ b/test/fixtures/defs/pets_authed.json
@@ -61,6 +61,13 @@
                         "required": false,
                         "type": "integer",
                         "format": "int32"
+                    },
+                    {
+                        "name": "custom-header",
+                        "in": "header",
+                        "description": "A custom header",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -188,7 +188,10 @@ Test('authentication', function (t) {
                     server.inject({
                         method: 'GET',
                         url: '/v1/petstore/pets',
-                        headers: { authorization: '12345' }
+                        headers: {
+                            authorization: '12345',
+                            'custom-header': 'Hello'
+                        }
                     }, function (response) {
                         t.strictEqual(response.statusCode, 200, 'OK status.');
 


### PR DESCRIPTION
- Fix for #50 
- Added `headers` validate config as a `Joi` object with `allowUnknown: true` option.