### PR TITLE
Add license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2016 PayPal
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "cover": "istanbul cover tape -- test/*.js",
     "lint": "jshint -c .jshintrc lib/*.js"
   },
+  "license": "Apache-2.0",
   "main": "./lib/index"
 }


### PR DESCRIPTION
I was alerted by a tool we use that this npm module is unlicensed.

The Apache License, Version 2.0 seems to be what you use in your modules. Please have a look and see if it is correct. I copied the license from `swaggerize-express`.
