### PR TITLE
Ensure validators are Joi schemas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,9 +47,7 @@ module.exports = {
 
         //Add all known routes
         routes.forEach(function (route) {
-            var config, formValidators, headers;
-
-            config = {
+            var config = {
                 pre: [],
                 handler: undefined,
                 cors: options.cors
@@ -72,50 +70,7 @@ module.exports = {
             }
 
             if (route.validators.length) {
-                config.validate = {};
-
-                //Input validation
-                route.validators.forEach(function (validator) {
-                    switch (validator.parameter.in) {
-                        case 'header':
-                            headers = headers || {};
-                            headers[validator.parameter.name] = validator.schema;
-                            break;
-                        case 'query':
-                            config.validate.query = config.validate.query || {};
-                            config.validate.query[validator.parameter.name] = validator.schema;
-                            break;
-                        case 'path':
-                            config.validate.params = config.validate.params || {};
-                            config.validate.params[validator.parameter.name] = validator.schema;
-                            break;
-                        case 'body':
-                            config.validate.payload = validator.schema;
-                            break;
-                        case 'formData':
-                            formValidators = formValidators || {};
-                            formValidators[validator.parameter.name] = function (value, next) {
-                                validator.validate(value, next);
-                            };
-                            break;
-                    }
-                });
-
-                if (headers && Object.keys(headers).length > 0) {
-                    config.validate.headers = Joi.object(headers).options({ allowUnknown: true });
-                }
-
-                if (!config.validate.payload && formValidators) {
-                    config.validate.payload = function (value, options, next) {
-                        Async.series(Object.keys(value).map(function (k) {
-                            return function (callback) {
-                                formValidators[k](value[k], callback);
-                            };
-                        }), function (error) {
-                            next(error);
-                        });
-                    };
-                }
+                config.validate = buildValidators(route.validators);
             }
 
             if (route.security) {
@@ -154,6 +109,62 @@ module.exports = {
         next();
     }
 };
+
+function buildValidators(validators) {
+    var validate = {}, formValidators, headers, query, params;
+
+    validators.forEach(function (validator) {
+        switch (validator.parameter.in) {
+            case 'header':
+                headers = headers || {};
+                headers[validator.parameter.name] = validator.schema;
+                break;
+            case 'query':
+                query = query || {};
+                query[validator.parameter.name] = validator.schema;
+                break;
+            case 'path':
+                params = params || {};
+                params[validator.parameter.name] = validator.schema;
+                break;
+            case 'body':
+                validate.payload = validator.schema;
+                break;
+            case 'formData':
+                formValidators = formValidators || {};
+                formValidators[validator.parameter.name] = function (value, next) {
+                    validator.validate(value, next);
+                };
+                break;
+        }
+    });
+
+    if (headers && Object.keys(headers).length > 0) {
+        validate.headers = Joi.object(headers).options({ allowUnknown: true });
+    }
+
+    if (query) {
+        validate.query = Joi.object(query);
+    }
+
+    if (params) {
+        validate.params = Joi.object(params);
+    }
+
+    if (!validate.payload && formValidators) {
+        validate.payload = function (value, options, next) {
+            Async.series(Object.keys(value).map(function (k) {
+                return function (callback) {
+                    formValidators[k](value[k], callback);
+                };
+            }), function (error) {
+                next(error);
+            });
+        };
+    }
+
+    return validate;
+}
 
 /**
  * Loads the api from a path, with support for yaml..

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "boom": "~2.8.0",
-    "hapi": "^13.3.0",
+    "hapi": "^15.2.0",
     "istanbul": "~0.2.3",
     "jshint": "^2.4.1",
     "tape": "^3.0.0"


### PR DESCRIPTION
- Convert objects to Joi schemas by passing the objects to `Joi.object()`
- Move construction of validators to a separate function because the linter complained about cyclomatic complexity