### PR TITLE
Engines Restriction >=4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "engines": {
-    "node": "4.x"
+    "node": ">=4.x"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
- Made the engine restriction be >=4.x

Was having problems installing with yarn with Node v7.1.0.