### PR TITLE
Ignore formData inputs not in schema

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,10 @@ module.exports = {
                     config.validate.payload = function (value, options, next) {
                         Async.series(Object.keys(value).map(function (k) {
                             return function (callback) {
+                                if (!formValidators[k]) {
+                                    return Async.setImmediate(callback);
+                                }
+
                                 formValidators[k](value[k], callback);
                             };
                         }), function (error) {

--- a/test/test-swaggerize-hapi.js
+++ b/test/test-swaggerize-hapi.js
@@ -274,6 +274,21 @@ Test('form data', function (t) {
             t.strictEqual(response.statusCode, 400, '400 status.');
         });
     });
+    
+    t.test('extra payload', function (t) {
+        t.plan(1);
+
+        server.inject({
+            method: 'POST',
+            url: '/v1/petstore/upload',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded'
+            },
+            payload: 'extra=1&name=thing&upload='
+        }, function (response) {
+            t.strictEqual(response.statusCode, 400, '400 status.');
+        });
+    });
 });
 
 Test('yaml', function (t) {


### PR DESCRIPTION
Currently if a formData input not in the schema is passed in a 500 will be returned.
This implementation ignores extra inputs, feel free to change it to return a 400 instead.

On another side, I could not manager to have all the test pass by giving some value to upload and asserting a 200. I get this error I don't know how to fix:

not ok 31 plan != count
  ---
    operator: fail
    expected: 3
    actual:   4
  ...