### PR TITLE
Added the ability to inject auth options for the swagger doc route

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The plugin will be registered as `swagger` on `server.plugins` with the followin
 
 - `api` - a valid Swagger 2.0 document.
 - `docspath` - the path to expose api docs for swagger-ui, etc. Defaults to `/`.
+- `docsauth` - *optional* auth options for api docs route. Defaults to server default (see [hapi route options](http://hapijs.com/api#route-options)).
 - `handlers` - either a directory structure for route handlers.
 - `vhost` - *optional* domain string (see [hapi route options](http://hapijs.com/api#route-options)).
 - `cors` - *optional* cors setting (see [hapi route options](http://hapijs.com/api#route-options)).

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ module.exports = {
         options.basedir = options.basedir || process.cwd();
         options.docspath = Utils.prefix(options.docspath || '/api-docs', '/');
         options.docspath = Utils.unsuffix(options.docspath, '/');
+        options.docsauth = options.hasOwnProperty('docsauth') ? options.docsauth : null;
         options.api.basePath = Utils.prefix(options.api.basePath || '/', '/');
         basePath = Utils.unsuffix(options.api.basePath, '/');
 
@@ -40,7 +41,8 @@ module.exports = {
                 handler: function (request, reply) {
                     reply(options.api);
                 },
-                cors: options.cors
+                cors: options.cors,
+                auth: options.docsauth
             },
             vhost: options.vhost
         });


### PR DESCRIPTION
**Problem:**
When the server has a default authorization strategy specified (ex: `server.auth.default('Bearer');`), the swagger document route will adhere to this strategy.  SwaggerUI allows you to inject your own auth settings for the UI route--but if the swagger docs endpoint is inaccessible because of the default auth, it will be impossible for UI to function.

**Resolution:**
An optional setting for specifying the auth options for the swagger docs route (only).  


