### PR TITLE
add docsauth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The plugin will be registered as `swagger` on `server.plugins` with the followin
 
 - `api` - a valid Swagger 2.0 document.
 - `docspath` - the path to expose api docs for swagger-ui, etc. Defaults to `/`.
+- `docsauth` - passed along as `auth` to the api docs route (see [hapi route options](http://hapijs.com/api#route-options)).
 - `handlers` - either a directory structure for route handlers.
 - `vhost` - *optional* domain string (see [hapi route options](http://hapijs.com/api#route-options)).
 - `cors` - *optional* cors setting (see [hapi route options](http://hapijs.com/api#route-options)).

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ module.exports = {
                 handler: function (request, reply) {
                     reply(options.api);
                 },
+                auth: options.docsauth,
                 cors: options.cors
             },
             vhost: options.vhost


### PR DESCRIPTION
passed along as `auth` to the api docs route (see [hapi route options](http://hapijs.com/api#route-options))
