### PR TITLE
Remove api_key requirement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,6 @@ module.exports = {
                     var securityDefinition = options.api.securityDefinitions[securityDefinitionName];
 
                     Assert.ok(securityDefinition, 'Security scheme not defined.');
-                    Assert.ok(securityDefinition.type === 'apiKey', 'Security schemes other than api_key are not supported.');
 
                     config.auth = config.auth || {};
                     config.auth.strategies = config.auth.strategies || [];


### PR DESCRIPTION
Other authentication options are supported by hapi plugins such as https://github.com/johnbrett/hapi-auth-bearer-token for oauth bearer token.

As there is no included handler for `api_key` and any middleware works this check restricts the use of the package and does not enhance the security.